### PR TITLE
Insert head styles before <link>

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,11 @@ import registerServiceWorker from "./registerServiceWorker";
 
 import "./styles/index.scss";
 
+const styles = [...document.querySelectorAll('head style')];
+const link = document.querySelector('link[type="text/css"]');
+
+styles.forEach(style => link.parentElement.insertBefore(style, link));
+
 const history = createHistory();
 
 ReactDOM.render(


### PR DESCRIPTION
Temporary fix to solve overriding styles, since order of operations for `style-loader` cannot be changed.